### PR TITLE
Update Java guidance in CLAUDE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@
 - Run specific test class: `mvn test -Dtest=TestClassName`
 
 ## Java Version Compatibility
-- Using Java 23
-- For testing with Java 23, add `-Dnet.bytebuddy.experimental=true` to JVM arguments
-- Required dependency versions for Java 23:
+- Using Java 21
+- For testing with Java 21, add `-Dnet.bytebuddy.experimental=true` to JVM arguments
+- Required dependency versions for Java 21:
   - Byte Buddy 1.14.12+
   - Mockito 5.10.0+
 


### PR DESCRIPTION
## Summary
- switch guidance from Java 23 to Java 21 in `CLAUDE.md`

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e851c00508331b9ef7a8a6ef6c1ec