### PR TITLE
Fix prerequisites bullet

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This project consists of:
 ## Prerequisites
 
 - Java 11 or higher
-- Gradle 7.0 or higher
+- Maven 3.8 or higher
 - Node.js 14.x or higher
 - npm 6.x or higher
 - PostgreSQL (for production)


### PR DESCRIPTION
## Summary
- update README to use Maven 3.8 or higher

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684e853120fc83319fe81e8105488167